### PR TITLE
Add mesos-dns to the slave image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,12 @@ RUN easy_install /mesos/build/src/python/dist/mesos.interface-*.egg
 RUN easy_install /mesos/build/src/python/dist/mesos.native-*.egg
 
 ####################
+# Mesos-DNS
+####################
+RUN wget https://dl.dropboxusercontent.com/u/4550074/mesos/mesos-dns -O /usr/bin/mesos-dns && \
+    chmod +x /usr/bin/mesos-dns
+
+####################
 # Isolator
 ####################
 
@@ -130,3 +136,5 @@ RUN wget https://github.com/Metaswitch/calico-docker/releases/download/v0.5.1/ca
 ADD ./init_scripts/etc/service/mesos_slave/run /etc/service/mesos_slave/run
 ADD ./init_scripts/etc/service/docker/run /etc/service/docker/run
 ADD ./init_scripts/etc/service/calico/run /etc/service/calico/run
+ADD ./init_scripts/etc/service/mesos-dns/run /etc/service/mesos-dns/run
+ADD ./init_scripts/etc/config/mesos-dns.json /etc/config/mesos-dns.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,3 @@
-dns:
-  image: devries/dnsmasq
-  links:
-  - mesosmaster
-  - slave1
-
 zookeeper:
   image: jplock/zookeeper:3.4.5
   hostname: zookeeper
@@ -47,6 +41,8 @@ slave1:
     - MESOS_ISOLATION=com_mesosphere_mesos_CalicoIsolator
     - MESOS_HOOKS=com_mesosphere_mesos_CalicoHook
     - ETCD_AUTHORITY=etcd:4001
+  dns:
+   - 192.168.255.254
 
 marathon:
   image: mesosphere/marathon:v0.8.1

--- a/init_scripts/etc/config/mesos-dns.json
+++ b/init_scripts/etc/config/mesos-dns.json
@@ -1,0 +1,21 @@
+{
+  "zk": "zk://zookeeper:2181/mesos",
+  "masters": ["mesosmaster:5050"],
+  "refreshSeconds": 60,
+  "ttl": 60,
+  "domain": "mesos",
+  "port": 53,
+  "resolvers": ["8.8.8.8"],
+  "timeout": 5,
+  "httpon": true,
+  "dsnon": true,
+  "httpport": 8123,
+  "externalon": true,
+  "listener": "0.0.0.0",
+  "SOAMname": "root.ns1.mesos",
+  "SOARname": "ns1.mesos",
+  "SOARefresh": 60,
+  "SOARetry":   600,
+  "SOAExpire":  86400,
+  "SOAMinttl": 60
+}

--- a/init_scripts/etc/service/mesos-dns/run
+++ b/init_scripts/etc/service/mesos-dns/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+ip addr add 192.168.255.254/32 dev lo
+exec 2>&1
+exec mesos-dns -config=/etc/config/mesos-dns.json


### PR DESCRIPTION
Docker only allows static nameservers to be configured, and
since we don't know the slave's runtime IP, we statically
define 192.168.255.254 to be the nameserver IP.

The start up script for mesos-dns binds this address to lo